### PR TITLE
fix #3: add support for Chromium browser.

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { canAccess, newLineRegex, sort } = require('./util');
 
 function darwin() {
-  const suffixes = ['/Contents/MacOS/Google Chrome Canary', '/Contents/MacOS/Google Chrome'];
+  const suffixes = ['/Contents/MacOS/Google Chrome Canary', '/Contents/MacOS/Google Chrome', '/Contents/MacOS/Chromium'];
 
   const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
     '/Versions/A/Frameworks/LaunchServices.framework' +
@@ -13,7 +13,7 @@ function darwin() {
 
   execSync(
     `${LSREGISTER} -dump` +
-    ' | grep -i \'google chrome\\( canary\\)\\?.app$\'' +
+    ' | grep -E -i \'(google chrome( canary)?|chromium).app$\'' +
     ' | awk \'{$1=""; print $0}\'')
     .toString()
     .split(newLineRegex)
@@ -28,10 +28,13 @@ function darwin() {
 
   // Retains one per line to maintain readability.
   const priorities = [
+    { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chromium.app`), weight: 49 },
     { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome.app`), weight: 50 },
     { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome Canary.app`), weight: 51 },
+    { regex: /^\/Applications\/.*Chromium.app/, weight: 99 },
     { regex: /^\/Applications\/.*Chrome.app/, weight: 100 },
     { regex: /^\/Applications\/.*Chrome Canary.app/, weight: 101 },
+    { regex: /^\/Volumes\/.*Chromium.app/, weight: -3 },
     { regex: /^\/Volumes\/.*Chrome.app/, weight: -2 },
     { regex: /^\/Volumes\/.*Chrome Canary.app/, weight: -1 }
   ];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -45,6 +45,7 @@ function linux() {
   const executables = [
     'google-chrome-stable',
     'google-chrome',
+    'chromium',
   ];
   executables.forEach((executable) => {
     try {

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -4,7 +4,7 @@ const { canAccess } = require('./util');
 function win32() {
   const installations = [];
   const suffixes = [
-    '\\Google\\Chrome SxS\\Application\\chrome.exe', '\\Google\\Chrome\\Application\\chrome.exe'
+    '\\Google\\Chrome SxS\\Application\\chrome.exe', '\\Google\\Chrome\\Application\\chrome.exe', '\\chrome-win32\\chrome.exe',
   ];
   const prefixes =
     [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];


### PR DESCRIPTION
Added entries on all supported platforms for Chromium browser.

The windows entry might be non-standard because the user has to manually install the browser by copying the content of the downloaded .zip file to the programs folder. Different users might choose different folder names. However, chances are that most users just use the same name as in the .zip file. So this name was added to the `lib/win32.js` file.