### PR TITLE
fix #2: support Alpine linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -12,7 +12,15 @@ function findChromeExecutablesForLinuxDesktop(folder) {
     // Output of the grep & print looks like:
     //    /opt/google/chrome/google-chrome --profile-directory
     //    /home/user/Downloads/chrome-linux/chrome-wrapper %U
-    let execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`)
+    let execPaths;
+    try {
+      execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    } catch (e) {
+      // for Alpine linux, brutally retry without "-R".
+      execPaths = execSync(`grep -Er "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    }
+
+    execPaths = execPaths
       .toString()
       .split(newLineRegex)
       .map((execPath) => execPath.replace(argumentsRegex, '$1'));


### PR DESCRIPTION
The patch just retries to execute "grep" with "-r" on linux in case an exception is thrown.