### PR TITLE
support install as npm package with git URL

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# files and directories to ignore when isntalled as
+# npm package via git URL
+
+.idea/
+node_modules/
+.appveyor.yml
+.editorconfig
+.git/
+.gitignore
+.travis.yml
+test/
+


### PR DESCRIPTION
Sometimes it is necessary to install latest or development version of npm modules, because their current release in the npm registry does not include vital patches.

This is possible with git URLs (see [`npm install`](https://docs.npmjs.com/cli/install)). In order to support this even better, a `.npmignore` file is added by this merge request to ignore development files not needed for the release.