### PR TITLE
support finding chrome on Toradex with Angstrom v2016.12

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# files and directories to ignore when isntalled as
+# npm package via git URL
+
+.idea/
+node_modules/
+.appveyor.yml
+.editorconfig
+.git/
+.gitignore
+.travis.yml
+test/
+

--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { canAccess, newLineRegex, sort } = require('./util');
 
 function darwin() {
-  const suffixes = ['/Contents/MacOS/Google Chrome Canary', '/Contents/MacOS/Google Chrome'];
+  const suffixes = ['/Contents/MacOS/Google Chrome Canary', '/Contents/MacOS/Google Chrome', '/Contents/MacOS/Chromium'];
 
   const LSREGISTER = '/System/Library/Frameworks/CoreServices.framework' +
     '/Versions/A/Frameworks/LaunchServices.framework' +
@@ -13,7 +13,7 @@ function darwin() {
 
   execSync(
     `${LSREGISTER} -dump` +
-    ' | grep -i \'google chrome\\( canary\\)\\?.app$\'' +
+    ' | grep -E -i \'(google chrome( canary)?|chromium).app$\'' +
     ' | awk \'{$1=""; print $0}\'')
     .toString()
     .split(newLineRegex)
@@ -28,10 +28,13 @@ function darwin() {
 
   // Retains one per line to maintain readability.
   const priorities = [
+    { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chromium.app`), weight: 49 },
     { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome.app`), weight: 50 },
     { regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome Canary.app`), weight: 51 },
+    { regex: /^\/Applications\/.*Chromium.app/, weight: 99 },
     { regex: /^\/Applications\/.*Chrome.app/, weight: 100 },
     { regex: /^\/Applications\/.*Chrome Canary.app/, weight: 101 },
+    { regex: /^\/Volumes\/.*Chromium.app/, weight: -3 },
     { regex: /^\/Volumes\/.*Chrome.app/, weight: -2 },
     { regex: /^\/Volumes\/.*Chrome Canary.app/, weight: -1 }
   ];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -12,7 +12,15 @@ function findChromeExecutablesForLinuxDesktop(folder) {
     // Output of the grep & print looks like:
     //    /opt/google/chrome/google-chrome --profile-directory
     //    /home/user/Downloads/chrome-linux/chrome-wrapper %U
-    let execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`)
+    let execPaths;
+    try {
+      execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    } catch (e) {
+      // for Alpine linux, brutally retry without "-R".
+      execPaths = execSync(`grep -Er "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    }
+
+    execPaths = execPaths
       .toString()
       .split(newLineRegex)
       .map((execPath) => execPath.replace(argumentsRegex, '$1'));

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -56,6 +56,7 @@ function linux() {
     'google-chrome',
     'chromium',
     'chromium-browser',
+    'chromium/chrome',   // on toradex machines "chromium" is a directory. seen on Angstrom v2016.12
   ];
   executables.forEach((executable) => {
     // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -45,6 +45,7 @@ function linux() {
   const executables = [
     'google-chrome-stable',
     'google-chrome',
+    'chromium-browser',
   ];
   executables.forEach((executable) => {
     try {
@@ -59,6 +60,7 @@ function linux() {
   });
 
   const priorities = [
+    { regex: /chromium/, weight: 53 },
     { regex: /chrome-wrapper$/, weight: 51 }, { regex: /google-chrome-stable$/, weight: 50 },
     { regex: /google-chrome$/, weight: 49 },
   ];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -45,6 +45,7 @@ function linux() {
   const executables = [
     'google-chrome-stable',
     'google-chrome',
+    'chromium',
   ];
   executables.forEach((executable) => {
     try {

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,7 +1,7 @@
 const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const { canAccess, sort, newLineRegex } = require('./util');
+const { canAccess, sort, isExecutable, newLineRegex } = require('./util');
 
 
 function findChromeExecutablesForLinuxDesktop(folder) {
@@ -70,7 +70,7 @@ function linux() {
     ].map((possiblePath) => {
       try {
         const chromePathToTest = possiblePath + '/' + executable;
-        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest)) {
+        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest) && isExecutable(chromePathToTest)) {
           installations.push(chromePathToTest);
           return chromePathToTest;
         }

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,5 +1,6 @@
 const { execSync, execFileSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 const { canAccess, sort, newLineRegex } = require('./util');
 
 
@@ -57,6 +58,33 @@ function linux() {
     'chromium-browser',
   ];
   executables.forEach((executable) => {
+    // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/
+    const validChromePaths = [
+      '/usr/bin',
+      '/usr/local/bin',
+      '/usr/sbin',
+      '/usr/local/sbin',
+      '/opt/bin',
+      '/usr/bin/X11',
+      '/usr/X11R6/bin'
+    ].map((possiblePath) => {
+      try {
+        const chromePathToTest = possiblePath + '/' + executable;
+        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest)) {
+          installations.push(chromePathToTest);
+          return chromePathToTest;
+        }
+      } catch (err) {
+        // not installed on this path or inaccessible
+      }
+      return undefined;
+    }).filter((foundChromePath) => foundChromePath);
+
+    // skip asking "which" command if the binary was found by searching the known paths.
+    if (validChromePaths && validChromePaths.length > 0) {
+      return;
+    }
+
     try {
       const chromePath =
         execFileSync('which', [executable]).toString().split(newLineRegex)[0];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -60,7 +60,9 @@ function linux() {
   });
 
   const priorities = [
-    { regex: /chrome-wrapper$/, weight: 51 }, { regex: /google-chrome-stable$/, weight: 50 },
+    { regex: /chromium$/, weight: 52 },
+    { regex: /chrome-wrapper$/, weight: 51 },
+    { regex: /google-chrome-stable$/, weight: 50 },
     { regex: /google-chrome$/, weight: 49 },
   ];
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,9 +33,23 @@ function canAccess(file) {
   }
 }
 
+function isExecutable(file) {
+  if (!file) {
+    return false;
+  }
+
+  try {
+    var stat = fs.statSync(file);
+    return stat && typeof stat.isFile === "function" && stat.isFile();
+  } catch (e) {
+    return false;
+  }
+}
+
 module.exports = {
   sort,
   canAccess,
+  isExecutable,
   newLineRegex,
 }
 

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -4,7 +4,7 @@ const { canAccess } = require('./util');
 function win32() {
   const installations = [];
   const suffixes = [
-    '\\Google\\Chrome SxS\\Application\\chrome.exe', '\\Google\\Chrome\\Application\\chrome.exe'
+    '\\Google\\Chrome SxS\\Application\\chrome.exe', '\\Google\\Chrome\\Application\\chrome.exe', '\\chrome-win32\\chrome.exe',
   ];
   const prefixes =
     [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -4,7 +4,10 @@ const { canAccess } = require('./util');
 function win32() {
   const installations = [];
   const suffixes = [
-    '\\Google\\Chrome SxS\\Application\\chrome.exe', '\\Google\\Chrome\\Application\\chrome.exe', '\\chrome-win32\\chrome.exe',
+    '\\Google\\Chrome SxS\\Application\\chrome.exe',
+    '\\Google\\Chrome\\Application\\chrome.exe',
+    '\\chrome-win32\\chrome.exe',
+    '\\Chromium\\Application\\chrome.exe'
   ];
   const prefixes =
     [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']];


### PR DESCRIPTION
On Toradex Angstrom v2016.12 chromium is located here `/usr/bin/chromium/chrome`. The previous detection mechanism found the base directory only - which can not be executed. This fix will filter for directories and find chromium on Toradex.