### PR TITLE
fix #14 use "find" instead of recursive "grep"

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -13,12 +13,7 @@ function findChromeExecutablesForLinuxDesktop(folder) {
     //    /opt/google/chrome/google-chrome --profile-directory
     //    /home/user/Downloads/chrome-linux/chrome-wrapper %U
     let execPaths;
-    try {
-      execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
-    } catch (e) {
-      // for Alpine linux, brutally retry without "-R".
-      execPaths = execSync(`grep -Er "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
-    }
+    execPaths = execSync(`find "${folder}" -type f -exec grep -E "${chromeExecRegex}" "{}" \\; | awk -F '=' '{print $2}'`);
 
     execPaths = execPaths
       .toString()


### PR DESCRIPTION
some grep versions do not support recursive search, eg: busybox
Because `find` seems to be available on nearly all platforms,
this is used instead to walk the directories and call grep
on each "*.desktop" file.

see: https://github.com/gwuhaolin/chrome-finder/issues/14

fix and close #14