### PR TITLE
Issue #16 chromium on toradex

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -55,6 +55,7 @@ function linux() {
     'google-chrome-stable',
     'google-chrome',
     'chromium',
+    'chromium-browser',
     'chromium/chrome',   // on toradex machines "chromium" is a directory. seen on Angstrom v2016.12
   ];
   executables.forEach((executable) => {
@@ -101,6 +102,7 @@ function linux() {
     { regex: /chrome-wrapper$/, weight: 51 },
     { regex: /google-chrome-stable$/, weight: 50 },
     { regex: /google-chrome$/, weight: 49 },
+    { regex: /chromium-browser$/, weight: 48 },
     { regex: /chrome$/, weight: 47 },
   ];
 

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,5 +1,6 @@
 const { execSync, execFileSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 const { canAccess, sort, newLineRegex } = require('./util');
 
 
@@ -56,6 +57,33 @@ function linux() {
     'chromium',
   ];
   executables.forEach((executable) => {
+    // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/
+    const validChromePaths = [
+      '/usr/bin',
+      '/usr/local/bin',
+      '/usr/sbin',
+      '/usr/local/sbin',
+      '/opt/bin',
+      '/usr/bin/X11',
+      '/usr/X11R6/bin'
+    ].map((possiblePath) => {
+      try {
+        const chromePathToTest = possiblePath + '/' + executable;
+        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest)) {
+          installations.push(chromePathToTest);
+          return chromePathToTest;
+        }
+      } catch (err) {
+        // not installed on this path or inaccessible
+      }
+      return undefined;
+    }).filter((foundChromePath) => foundChromePath);
+
+    // skip asking "which" command if the binary was found by searching the known paths.
+    if (validChromePaths && validChromePaths.length > 0) {
+      return;
+    }
+
     try {
       const chromePath =
         execFileSync('which', [executable]).toString().split(newLineRegex)[0];

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -55,6 +55,7 @@ function linux() {
     'google-chrome-stable',
     'google-chrome',
     'chromium',
+    'chromium/chrome',   // on toradex machines "chromium" is a directory. seen on Angstrom v2016.12
   ];
   executables.forEach((executable) => {
     // see http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/
@@ -100,6 +101,7 @@ function linux() {
     { regex: /chrome-wrapper$/, weight: 51 },
     { regex: /google-chrome-stable$/, weight: 50 },
     { regex: /google-chrome$/, weight: 49 },
+    { regex: /chrome$/, weight: 47 },
   ];
 
   return sort(Array.from(new Set(installations.filter(Boolean))), priorities);

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,7 +1,7 @@
 const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const { canAccess, sort, newLineRegex } = require('./util');
+const { canAccess, sort, isExecutable, newLineRegex } = require('./util');
 
 
 function findChromeExecutablesForLinuxDesktop(folder) {
@@ -69,7 +69,7 @@ function linux() {
     ].map((possiblePath) => {
       try {
         const chromePathToTest = possiblePath + '/' + executable;
-        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest)) {
+        if (fs.existsSync(chromePathToTest) && canAccess(chromePathToTest) && isExecutable(chromePathToTest)) {
           installations.push(chromePathToTest);
           return chromePathToTest;
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,9 +33,23 @@ function canAccess(file) {
   }
 }
 
+function isExecutable(file) {
+  if (!file) {
+    return false;
+  }
+
+  try {
+    var stat = fs.statSync(file);
+    return stat && typeof stat.isFile === "function" && stat.isFile();
+  } catch (e) {
+    return false;
+  }
+}
+
 module.exports = {
   sort,
   canAccess,
+  isExecutable,
   newLineRegex,
 }
 


### PR DESCRIPTION
* fixes #16 (closes #16): finding Chromium on Toradex Linux
* supports chromium on Raspbian, because chromium is named `chromium-browser` there

## Toradex Linux

Because very often there is no `which` command on custom built Toradex linux, a list of common locations for binaries are checked, too.

## Raspbian

Rapsbian uses a custom name for Chromium "chromium-browser". So this name is added to the list of browser names.
