### PR TITLE
Fix Catalina Chrome detection

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -11,10 +11,9 @@ function darwin() {
 
   const installations = [];
 
-  execSync(
-    `${LSREGISTER} -dump` +
-    ' | grep -E -i \'(google chrome( canary)?|chromium).app$\'' +
-    ' | awk \'{$1=""; print $0}\'')
+  execSync(`
+    ${LSREGISTER} -dump | grep -E -i -o '/.+(google chrome( canary)?|chromium)\\.app(\\s|$)' | grep -E -v 'Caches|TimeMachine|Temporary|/Volumes|\\.Trash'
+  `)
     .toString()
     .split(newLineRegex)
     .forEach((inst) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ const findChrome = require('../lib/index');
 describe('chrome-finder', function () {
 
   it('#findChrome()', function () {
+    this.timeout(10000);
     const chromePath = findChrome();
     fs.accessSync(chromePath, fs.constants.X_OK);
     console.log(chromePath);


### PR DESCRIPTION
This fix is taken from [nuxt/tib](https://github.com/nuxt/tib) repo

- Should solve the Catalina Chrome detection issue
- Had to increase test timeout from default `2000` to `10000` because now it takes longer to detect on macOS

@gwuhaolin Please have a look.