### PR TITLE
Close stderr and stdin streams when launching 'which'

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -83,7 +83,7 @@ function linux() {
 
     try {
       const chromePath =
-        execFileSync('which', [executable]).toString().split(newLineRegex)[0];
+        execFileSync('which', [executable], {stdio: [null, 'pipe', null]}).toString().split(newLineRegex)[0];
       if (canAccess(chromePath)) {
         installations.push(chromePath);
       }


### PR DESCRIPTION
chrome-finder invokes the 'which' command-line utility to locate Chrome/Chromium binaries that are not in the list of expected installation locations.

On systems that have the GNU version of 'which' installed, 'which' writes messages to the standard error stream (stderr) when the specified file cannot be found.

On such a system, whenever findChrome() is called, it will litter the console with annoying messages like this:

```
which: no chromium in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
which: no chromium-browser in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
which: no chrome in (./chromium)
```

By closing the stderr stream, these messages are suppressed. It was also decided to close the standard input stream (stdin) as well, as it is not being used.